### PR TITLE
Fix name generator and reload doc after file upload

### DIFF
--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -89,9 +89,12 @@ class S3Operations(object):
 
         if not doc_path:
             if self.folder_name:
-                final_key = self.folder_name + "/" + year + "/" + month + \
-                    "/" + day + "/" + parent_doctype + "/" + key + "_" + \
-                    file_name
+                if parent_doctype:
+                    final_key = self.folder_name + "/" + year + "/" + month + "/" + \
+                    day + "/" + parent_doctype + "/" + key + "_" + file_name
+                else:
+                    final_key = self.folder_name + "/" + year + "/" + month + "/" + \
+                    day + "/" + key + "_" + file_name
             else:
                 final_key = year + "/" + month + "/" + day + "/" + \
                     parent_doctype + "/" + key + "_" + file_name
@@ -228,14 +231,13 @@ def file_upload_to_s3(doc, method):
                 key
             )
         os.remove(file_path)
-        doc = frappe.db.sql("""UPDATE `tabFile` SET file_url=%s, folder=%s,
+
+        frappe.db.sql("""UPDATE `tabFile` SET file_url=%s, folder=%s,
             old_parent=%s, content_hash=%s WHERE name=%s""", (
             file_url, 'Home/Attachments', 'Home/Attachments', key, doc.name))
 
-        if frappe.get_meta(parent_doctype).get('image_field'):
-            frappe.db.set_value(parent_doctype, parent_name, frappe.get_meta(parent_doctype).get('image_field'), file_url)
-
         frappe.db.commit()
+        doc.reload()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
1. Fix file name generator when 'parent_doctype' value is not present.
2. Reload doc after uploading file to s3.